### PR TITLE
Fix syntax highlighting for ForContext logger variables

### DIFF
--- a/SerilogSyntax/Utilities/SerilogCallDetector.cs
+++ b/SerilogSyntax/Utilities/SerilogCallDetector.cs
@@ -15,7 +15,8 @@ internal static class SerilogCallDetector
     [
         "Log", "log", "_log", "logger", "Logger", "outputTemplate",
         "Filter", "ByExcluding", "ByIncludingOnly", 
-        "WithComputed", "ExpressionTemplate", "Conditional", "When"
+        "WithComputed", "ExpressionTemplate", "Conditional", "When",
+        ".Information", ".Debug", ".Warning", ".Error", ".Fatal", ".Verbose"
     ];
     
     private static readonly HashSet<string> SerilogMethods = new(StringComparer.OrdinalIgnoreCase)
@@ -31,10 +32,10 @@ internal static class SerilogCallDetector
     /// <summary>
     /// Regex pattern that matches Serilog method calls and configuration templates.
     /// Supports both direct Serilog calls and Microsoft.Extensions.Logging integration.
-    /// Also supports Serilog.Expressions API calls.
+    /// Also supports Serilog.Expressions API calls and variables assigned from ForContext calls.
     /// </summary>
     private static readonly Regex SerilogCallRegex = new(
-        @"(?:\b\w+\.(?:ForContext(?:<[^>]+>)?\([^)]*\)\.)?(?:Log(?:Verbose|Debug|Information|Warning|Error|Critical|Fatal)|(?:Verbose|Debug|Information|Warning|Error|Fatal|Write)|BeginScope)\s*\()|(?:outputTemplate\s*:\s*)|(?:\.?(?:Filter\.)?(?:ByExcluding|ByIncludingOnly)\s*\()|(?:\.?(?:Enrich\.)?(?:WithComputed|When)\s*\()|(?:\.?(?:WriteTo\.)?Conditional\s*\()|(?:new\s+ExpressionTemplate\s*\()",
+        @"(?:\b\w+\.(?:ForContext(?:<[^>]+>)?\([^)]*\)\.)?(?:Log(?:Verbose|Debug|Information|Warning|Error|Critical|Fatal)|(?:Verbose|Debug|Information|Warning|Error|Fatal|Write)|BeginScope)\s*\()|(?:\b\w+\.(?:Verbose|Debug|Information|Warning|Error|Fatal|Write)\s*\()|(?:\.(?:Verbose|Debug|Information|Warning|Error|Fatal|Write)\s*\()|(?:outputTemplate\s*:\s*)|(?:\.?(?:Filter\.)?(?:ByExcluding|ByIncludingOnly)\s*\()|(?:\.?(?:Enrich\.)?(?:WithComputed|When)\s*\()|(?:\.?(?:WriteTo\.)?Conditional\s*\()|(?:new\s+ExpressionTemplate\s*\()",
         RegexOptions.Compiled);
 
     /// <summary>


### PR DESCRIPTION
## Description
Template properties like `{ListenUri}` were not highlighted when using logger variables created from ForContext calls (e.g., `var program = log.ForContext<Program>()`). This fix enables proper syntax highlighting for Serilog method calls on arbitrary variable names assigned from ForContext operations.

**Root cause:** The SerilogCallDetector regex patterns and quick-check logic only recognized standard logger variable names like `logger`, `log`, `_log` etc., but not arbitrary variable names like `program` that hold logger instances from ForContext calls.

**Solution:**
- Enhanced regex pattern to match chained method calls starting with `.Information(`, `.Debug(`, etc.
- Added quick-check patterns for dotted method calls (`.Information`, `.Debug`, etc.)
- Implemented duplicate processing detection to prevent overlapping matches between different regex patterns
- Added logic to skip multi-line ForContext processing when new chained patterns already handle the cases

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation update

## Checklist
- [x] Tests pass (`.\scripts\test.ps1`)
- [x] Benchmarks checked (if performance-related)
- [ ] Documentation updated (if needed)

## Additional notes
Fixes #7 