### PR TITLE
fix: Support LogError calls with exception parameters for syntax highlighting

### DIFF
--- a/Example/ExampleService.cs
+++ b/Example/ExampleService.cs
@@ -379,6 +379,19 @@ Timestamp: {Timestamp:yyyy-MM-dd HH:mm:ss}
         logger.LogWarning("Legacy format: Error {0} occurred in method {1} at line {2}",
             "ValidationFailed", "ProcessData", 42);
 
+        // LogError with exception parameter examples (demonstrates exception parameter highlighting)
+        var userId = 42;
+        var errorCode = "E123";
+        var errorMessage = "Something went wrong";
+        
+        // Example 1: Exception with string literal constructor
+        logger.LogError(new Exception("Database connection failed"), "Error processing {UserId} with {ErrorCode} and {Message}",
+            userId, errorCode, errorMessage);
+        
+        // Example 2: Exception with variable constructor  
+        logger.LogError(new Exception(errorMessage), "Failed to validate {UserId} with status {ErrorCode} and details {Message}",
+            userId, errorCode, errorMessage);
+
         await Task.Delay(100);
     }
 


### PR DESCRIPTION
## Description
LogError calls with exception parameters like `logger.LogError(new Exception("error"), "User {UserId} failed", userId)` were not getting syntax highlighting for the message template properties, while the exception constructor string was incorrectly being highlighted instead.

**Root cause:** The string literal parser in `FindStringLiteral()` was treating the first string literal found (exception constructor parameter) as the message template, instead of identifying that LogError with exception parameters has the actual message template as the second parameter.

**Solution:**
- Added `IsLogErrorWithExceptionParameter()` method that analyzes parameter structure by tracking parenthesis depth and comma positions to detect LogError patterns with exception parameters
- Enhanced `FindStringLiteral()` with `skipFirstString` parameter to skip the exception parameter and locate the actual message template
- Handles both string literal exception constructors (`new Exception("literal")`) and variable constructors (`new Exception(variable)`) through comma detection logic
- Added tests covering both LogError exception parameter scenarios

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation update

## Checklist
- [x] Tests pass (`.\scripts\test.ps1`)
- [ ] Benchmarks checked (if performance-related)
- [ ] Documentation updated (if needed)

## Additional notes
Fixes #12 